### PR TITLE
build: correct link order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SRC_H=$(wildcard src/*/*.h)
 defualt: nui run
 
 nui: $(OBJ)
-	gcc $(CFLAGS) $(LDFLAGS) $^ -o $@
+	gcc $(CFLAGS) $^ $(LDFLAGS) -o $@
 
 bin/%.o: src/%.c $(SRC_H) | bin/common/ bin/game/ bin/client/ bin/renderer/ bin/pipeline/ bin/gl/ bin/ngui/
 	gcc $(INCLUDE) $(CFLAGS) -c -o $@ $<
@@ -38,6 +38,9 @@ bin/ngui/: | bin/
 
 bin/:
 	mkdir -p $@
+
+clean:
+	rm -f $(OBJ)
 
 run:
 	./nui


### PR DESCRIPTION
Since linking is order dependent, moving the library linking after object files resolves a linker issue I was encountering on Ubuntu based distros:

**Issue**
```
gcc -O3 -lSDL2 -lSDL2_image -lm -lGL -lGLEW -lfreetype -pthread bin/client/main.o bin/client/sdl.o bin/common/file.o bin/common/path.o bin/game/bsp.o bin/game/game.o bin/game/hull.o bin/game/map.o bin/game/player.o bin/gl/gl.o bin/gl/mesh.o bin/gl/quad_buffer.o bin/gl/quad.o bin/gl/shader.o bin/ngui/ngui.o bin/pipeline/akarin.o bin/pipeline/chise.o bin/pipeline/misaki.o bin/pipeline/reflect.o bin/renderer/camera.o bin/renderer/defer.o bin/renderer/frame.o bin/renderer/light.o bin/renderer/material.o bin/renderer/model.o bin/renderer/renderer.o bin/renderer/skybox.o bin/renderer/ssao.o bin/renderer/wave.o -o nui
/usr/bin/ld: bin/gl/shader.o: warning: relocation against `__glewAttachShader' in read-only section `.text'
/usr/bin/ld: bin/client/sdl.o: in function `key_event':
sdl.c:(.text+0x54): undefined reference to `SDL_StopTextInput'
/usr/bin/ld: sdl.c:(.text+0xd4): undefined reference to `SDL_StartTextInput'
/usr/bin/ld: bin/client/sdl.o: in function `sdl_poll':
sdl.c:(.text+0x134): undefined reference to `SDL_PollEvent'
/usr/bin/ld: sdl.c:(.text+0x170): undefined reference to `SDL_PollEvent'
/usr/bin/ld: bin/client/sdl.o: in function `sdl_init':
```

**Linking libraries later (resolved)**
```
gcc -O3 bin/client/main.o bin/client/sdl.o bin/common/file.o bin/common/path.o bin/game/bsp.o bin/game/game.o bin/game/hull.o bin/game/map.o bin/game/player.o bin/gl/gl.o bin/gl/mesh.o bin/gl/quad_buffer.o bin/gl/quad.o bin/gl/shader.o bin/ngui/ngui.o bin/pipeline/akarin.o bin/pipeline/chise.o bin/pipeline/misaki.o bin/pipeline/reflect.o bin/renderer/camera.o bin/renderer/defer.o bin/renderer/frame.o bin/renderer/light.o bin/renderer/material.o bin/renderer/model.o bin/renderer/renderer.o bin/renderer/skybox.o bin/renderer/ssao.o bin/renderer/wave.o -lSDL2 -lSDL2_image -lm -lGL -lGLEW -lfreetype -pthread -o nui
```

